### PR TITLE
Add photo carousel

### DIFF
--- a/src/components/about.ts
+++ b/src/components/about.ts
@@ -1,20 +1,147 @@
+import { Photo } from '../types/photo';
+
 export type AboutSectionProps = {
-    imageSrc: string;
-    imageAlt: string;
+    alias: string;
     title: string;
     subtitle?: string;
-    aboutItems: Array<string>;
+    aboutItems: Array<string> | undefined;
+    initialPhoto: Photo;
+    photos: Photo[];
+    numPhotos: number;
 };
 
-export function renderAboutSection({ imageSrc, imageAlt, title, subtitle, aboutItems }: AboutSectionProps): string {
-    const listHtml = aboutItems.map((item) => `<li>${item}</li>`).join('');
+export type PhotoCarouselProps = {
+    alias: string;
+    imageSrc: string;
+    imageAlt: string;
+    nextIndex: number;
+    prevIndex: number;
+    nextImageSrc?: string;
+    prevImageSrc?: string;
+    currentIndex?: number;
+    numPhotos?: number;
+    transitionDirection?: 'next' | 'prev';
+};
+
+export function renderPhotoCarousel({
+    imageSrc,
+    imageAlt,
+    alias,
+    nextIndex,
+    prevIndex,
+    nextImageSrc,
+    prevImageSrc,
+    currentIndex = 0,
+    numPhotos = 1,
+    transitionDirection
+}: PhotoCarouselProps): string {
+    const showNavigation = numPhotos > 1;
 
     return /* html */ `
-        <img
-            alt="${imageAlt}"
-            src="${imageSrc}"
-            class="max-h-[480px] w-full object-cover"
-        />
+        <div
+            id="photo-carousel"
+            class="relative bg-stone-900"
+            tabindex="0"
+            ${transitionDirection ? `data-direction="${transitionDirection}"` : ''}
+            role="region"
+            aria-label="Photo carousel"
+            aria-live="polite"
+            hx-on:keydown="${
+                showNavigation
+                    ? `
+                if (event.key === 'ArrowLeft') {
+                    event.preventDefault();
+                    this.querySelector('[aria-label=\\'Previous photo\\']')?.click();
+                } else if (event.key === 'ArrowRight') {
+                    event.preventDefault();
+                    this.querySelector('[aria-label=\\'Next photo\\']')?.click();
+                }
+            `
+                    : ''
+            }"
+            hx-on::after-swap="this.focus()"
+            hx-on::before-request="this.querySelectorAll('button').forEach(b => b.disabled = true)"
+            hx-on::after-settle="this.querySelectorAll('button').forEach(b => b.disabled = false)"
+        >
+            ${nextImageSrc ? `<link rel="prefetch" href="${nextImageSrc}" as="image">` : ''}
+            ${prevImageSrc ? `<link rel="prefetch" href="${prevImageSrc}" as="image">` : ''}
+            <img
+                alt="${imageAlt}"
+                src="${imageSrc}"
+                class="max-h-[480px] min-h-[360px] w-full object-contain carousel-image"
+            />
+            <span class="sr-only" aria-live="polite">Photo ${currentIndex + 1} of ${numPhotos}: ${imageAlt}</span>
+            ${
+                showNavigation
+                    ? /* html */ `
+                <div class="absolute top-4 right-4 bg-white/60 text-gray-800 px-3 py-1 rounded-full text-sm animate-fade-out">
+                    ${currentIndex + 1} / ${numPhotos}
+                </div>`
+                    : ''
+            }
+            ${
+                showNavigation
+                    ? /* html */ `
+                <button
+                    class="absolute top-1/2 -translate-y-1/2 left-2 bg-white/50 hover:bg-white/90 rounded-full w-8 h-8 flex items-center justify-center shadow-md hover:shadow-lg cursor-pointer transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                    hx-get="/api/cats/about/${alias}/photos/${prevIndex.toString()}?direction=prev"
+                    hx-swap="innerHTML swap:0.3s"
+                    hx-target="#photo-carousel"
+                    hx-indicator="#photo-carousel"
+                    aria-label="Previous photo"
+                >
+                    <i class="fa-solid fa-chevron-left text-gray-700"></i>
+                </button>
+                <button
+                    class="absolute top-1/2 -translate-y-1/2 right-2 bg-white/50 hover:bg-white/90 rounded-full w-8 h-8 flex items-center justify-center shadow-md hover:shadow-lg cursor-pointer transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                    hx-get="/api/cats/about/${alias}/photos/${nextIndex.toString()}?direction=next"
+                    hx-swap="innerHTML swap:0.3s"
+                    hx-target="#photo-carousel"
+                    hx-indicator="#photo-carousel"
+                    aria-label="Next photo"
+                >
+                    <i class="fa-solid fa-chevron-right text-gray-700"></i>
+                </button>
+            `
+                    : ''
+            }
+            <div class="htmx-indicator absolute inset-0 bg-black/20 flex items-center justify-center pointer-events-none">
+                <i class="fa-solid fa-spinner fa-spin text-white"></i>
+            </div>
+        </div>
+    `;
+}
+
+export function renderAboutSection({
+    alias,
+    title,
+    subtitle,
+    aboutItems = [],
+    initialPhoto,
+    photos,
+    numPhotos
+}: AboutSectionProps): string {
+    const listHtml = aboutItems.map((item) => `<li>${item}</li>`).join('');
+
+    const nextPhotoIndex = numPhotos > 1 ? 1 : 0;
+    const prevPhotoIndex = numPhotos - 1;
+
+    const { src, altText } = initialPhoto;
+    const nextImageSrc = photos[nextPhotoIndex]?.src;
+    const prevImageSrc = photos[prevPhotoIndex]?.src;
+
+    return /* html */ `
+        ${renderPhotoCarousel({
+            alias,
+            imageSrc: src,
+            imageAlt: altText,
+            nextIndex: nextPhotoIndex,
+            prevIndex: prevPhotoIndex,
+            nextImageSrc,
+            prevImageSrc,
+            currentIndex: 0,
+            numPhotos
+        })}
         <div class="p-8">
             <h2 class="${subtitle ? 'mb-2' : 'mb-4'} text-2xl font-bold text-gray-800">${title}</h2>
             ${subtitle ? /* html */ `<p class="mb-4 text-gray-500 italic">${subtitle}</p>` : ''}

--- a/src/data/cats.ts
+++ b/src/data/cats.ts
@@ -1,6 +1,8 @@
 import { Cat } from '../types/cat.js';
 import { getAssetUrl } from '../utils/assets.js';
 
+export const VALID_ALIASES = ['groucho', 'chica', 'groucho_and_chica'];
+
 export const catsData: { [alias: string]: Cat } = {
     groucho: {
         alias: 'groucho',
@@ -19,10 +21,94 @@ export const catsData: { [alias: string]: Cat } = {
             'Loves head scratches',
             'Prefers horizontal scratch surfaces'
         ],
-        coverPhotoImgSrc: getAssetUrl('groucho', 1),
-        coverPhotoImgAlt: 'Groucho the Cat, laying down',
         navigationThumbnailImgSrc: getAssetUrl('groucho', 'nav'),
-        navigationThumbnailImgAlt: 'Groucho the Cat, laying on a woven blanket'
+        navigationThumbnailImgAlt: 'Groucho the Cat, laying on a woven blanket',
+        photos: [
+            {
+                src: getAssetUrl('groucho', 1),
+                altText: 'Groucho the Cat, laying down'
+            },
+            {
+                src: getAssetUrl('groucho', 2),
+                altText: 'Groucho the Cat, laying awake on an arm'
+            },
+            {
+                src: getAssetUrl('groucho', 3),
+                altText: 'Groucho the Cat, laying asleep on an arm'
+            },
+            {
+                src: getAssetUrl('groucho', 4),
+                altText: 'Groucho the Cat, laying down on a woven blanket'
+            },
+            {
+                src: getAssetUrl('groucho', 5),
+                altText: 'Groucho the Cat, laying down on a couch'
+            },
+            {
+                src: getAssetUrl('groucho', 6),
+                altText: 'Groucho the Cat'
+            },
+            {
+                src: getAssetUrl('groucho', 7),
+                altText: 'Groucho the Cat, sitting by a window overlooking a city'
+            },
+            {
+                src: getAssetUrl('groucho', 8),
+                altText: 'Groucho the Cat, sitting by a window overlooking a city'
+            },
+            {
+                src: getAssetUrl('groucho', 9),
+                altText: 'Groucho the Cat, laying inside a cardboard box'
+            },
+            {
+                src: getAssetUrl('groucho', 10),
+                altText: 'Groucho the Cat, laying down on a small table'
+            },
+            {
+                src: getAssetUrl('groucho', 11),
+                altText: 'Groucho the Cat'
+            },
+            {
+                src: getAssetUrl('groucho', 12),
+                altText: 'Groucho the Cat'
+            },
+            {
+                src: getAssetUrl('groucho', 13),
+                altText: 'Groucho the Cat, standing by an open window overlooking a city'
+            },
+            {
+                src: getAssetUrl('groucho', 14),
+                altText: 'Groucho the Cat, sitting in a ripped-open cardboard box'
+            },
+            {
+                src: getAssetUrl('groucho', 15),
+                altText: 'Groucho the Cat, sitting in a cardboard box'
+            },
+            {
+                src: getAssetUrl('groucho', 16),
+                altText: 'Groucho the Cat, laying down on a keyboard'
+            },
+            {
+                src: getAssetUrl('groucho', 17),
+                altText: 'Groucho the Cat, sitting in a Hello Fresh cardboard box'
+            },
+            {
+                src: getAssetUrl('groucho', 18),
+                altText: 'Groucho the Cat, laying down'
+            },
+            {
+                src: getAssetUrl('groucho', 19),
+                altText: 'Groucho the Cat, laying down on an arm and chest'
+            },
+            {
+                src: getAssetUrl('groucho', 20),
+                altText: 'Groucho the Cat, laying down by a keyboard'
+            },
+            {
+                src: getAssetUrl('groucho', 21),
+                altText: 'Groucho the Cat, sitting on a lap'
+            }
+        ]
     },
     chica: {
         alias: 'chica',
@@ -41,9 +127,205 @@ export const catsData: { [alias: string]: Cat } = {
             'Loves whole body pets',
             'Prefers vertical scratch surfaces'
         ],
-        coverPhotoImgSrc: getAssetUrl('chica', 1),
-        coverPhotoImgAlt: 'Chica the Cat, laying down on a drying rack',
         navigationThumbnailImgSrc: getAssetUrl('chica', 'nav'),
-        navigationThumbnailImgAlt: 'Chica the Cat, sitting by a window overlooking a city'
+        navigationThumbnailImgAlt: 'Chica the Cat, sitting by a window overlooking a city',
+        photos: [
+            {
+                src: getAssetUrl('chica', 1),
+                altText: 'Chica the Cat, laying down on a drying rack'
+            },
+            {
+                src: getAssetUrl('chica', 2),
+                altText: 'Chica the Cat, laying down on carpet'
+            },
+            {
+                src: getAssetUrl('chica', 3),
+                altText: 'Chica the Cat, laying asleep on a woven blanket'
+            },
+            {
+                src: getAssetUrl('chica', 4),
+                altText: 'Chica the Cat, holding a wire'
+            },
+            {
+                src: getAssetUrl('chica', 5),
+                altText: 'Chica the Cat, laying down on a bed'
+            },
+            {
+                src: getAssetUrl('chica', 6),
+                altText: 'Chica the Cat, laying down on an arm'
+            },
+            {
+                src: getAssetUrl('chica', 7),
+                altText: 'Chica the Cat, sitting on a cat shaped rug'
+            },
+            {
+                src: getAssetUrl('chica', 8),
+                altText: 'Chica the Cat, standing on a door frame'
+            },
+            {
+                src: getAssetUrl('chica', 9),
+                altText: 'Chica the Cat, asleep while hugging an arm'
+            },
+            {
+                src: getAssetUrl('chica', 10),
+                altText: 'Chica the Cat, peeking out the side of an office chair'
+            },
+            {
+                src: getAssetUrl('chica', 11),
+                altText: 'Chica the Cat, laying asleep on a drying rack'
+            },
+            {
+                src: getAssetUrl('chica', 12),
+                altText: 'Chica the Cat, sitting on top of a couch pillow'
+            },
+            {
+                src: getAssetUrl('chica', 13),
+                altText: 'Chica the Cat, laying asleep on a mouse pad'
+            },
+            {
+                src: getAssetUrl('chica', 14),
+                altText: 'Chica the Cat, laying down in a small play house'
+            },
+            {
+                src: getAssetUrl('chica', 15),
+                altText: 'Chica the Cat, looking outside a window'
+            },
+            {
+                src: getAssetUrl('chica', 16),
+                altText: 'Chica the Cat, looking outside a window'
+            },
+            {
+                src: getAssetUrl('chica', 17),
+                altText: 'Chica the Cat, laying asleep on a table by a window'
+            },
+            {
+                src: getAssetUrl('chica', 18),
+                altText: 'Chica the Cat, laying down on an office chair with sunlight on her'
+            },
+            {
+                src: getAssetUrl('chica', 19),
+                altText: 'Chica the Cat'
+            },
+            {
+                src: getAssetUrl('chica', 20),
+                altText: 'Chica the Cat, sitting on a hoodie with similar colors as her'
+            },
+            {
+                src: getAssetUrl('chica', 21),
+                altText: 'Chica the Cat, laying asleep on a couch'
+            },
+            {
+                src: getAssetUrl('chica', 22),
+                altText: 'Chica the Cat, sitting by her water and food dispensers'
+            },
+            {
+                src: getAssetUrl('chica', 23),
+                altText: 'Chica the Cat'
+            }
+        ]
+    },
+    groucho_and_chica: {
+        alias: 'groucho_and_chica',
+        displayName: 'Groucho and Chica',
+        navigationThumbnailImgSrc: getAssetUrl('groucho_and_chica', 'nav'),
+        navigationThumbnailImgAlt: 'Groucho and Chica together',
+        photos: [
+            {
+                src: getAssetUrl('groucho_and_chica', 1),
+                altText: 'Groucho and Chica laying down together on a blanket'
+            },
+            {
+                src: getAssetUrl('groucho_and_chica', 2),
+                altText: 'Groucho and Chica. Chica is in a playhouse while Groucho is outside it'
+            },
+            {
+                src: getAssetUrl('groucho_and_chica', 3),
+                altText: 'Groucho and Chica, eating together on a table by a window overlooking a city'
+            },
+            {
+                src: getAssetUrl('groucho_and_chica', 4),
+                altText: 'Groucho and Chica, both sitting on separate steps of a step ladder'
+            },
+            {
+                src: getAssetUrl('groucho_and_chica', 5),
+                altText: 'Groucho and Chica, laying down on a desk'
+            },
+            {
+                src: getAssetUrl('groucho_and_chica', 6),
+                altText: 'Groucho and Chica, sitting together on an office chair'
+            },
+            {
+                src: getAssetUrl('groucho_and_chica', 7),
+                altText: 'Groucho and Chica, sitting together on an office chair'
+            },
+            {
+                src: getAssetUrl('groucho_and_chica', 8),
+                altText: 'Groucho and Chica, laying down together on a desk'
+            },
+            {
+                src: getAssetUrl('groucho_and_chica', 9),
+                altText: 'Groucho and Chica, laying down together on a desk'
+            },
+            {
+                src: getAssetUrl('groucho_and_chica', 10),
+                altText: 'Groucho and Chica, sitting together on a small chair'
+            },
+            {
+                src: getAssetUrl('groucho_and_chica', 11),
+                altText: 'Groucho and Chica, sitting together in a pet carrier'
+            },
+            {
+                src: getAssetUrl('groucho_and_chica', 12),
+                altText: 'Groucho and Chica, laying together on a table by a window overlooking a city'
+            },
+            {
+                src: getAssetUrl('groucho_and_chica', 13),
+                altText: 'Groucho licking Chica clean'
+            },
+            {
+                src: getAssetUrl('groucho_and_chica', 14),
+                altText: 'Groucho and Chica, laying together in a small playhouse'
+            },
+            {
+                src: getAssetUrl('groucho_and_chica', 15),
+                altText: 'Groucho and Chica, laying together in a small playhouse'
+            },
+            {
+                src: getAssetUrl('groucho_and_chica', 16),
+                altText: 'Groucho and Chica, both laying down on a couch'
+            },
+            {
+                src: getAssetUrl('groucho_and_chica', 17),
+                altText: 'Groucho and Chica, both laying down on a drying rack'
+            },
+            {
+                src: getAssetUrl('groucho_and_chica', 18),
+                altText: 'Groucho and Chica, both sitting on a bed'
+            },
+            {
+                src: getAssetUrl('groucho_and_chica', 19),
+                altText: 'Groucho and Chica, both laying down in a cardboard box'
+            },
+            {
+                src: getAssetUrl('groucho_and_chica', 20),
+                altText: 'Groucho and Chica, both laying down on a couch'
+            },
+            {
+                src: getAssetUrl('groucho_and_chica', 21),
+                altText: 'Groucho and Chica, both standing on a table by a window overlooking a city'
+            },
+            {
+                src: getAssetUrl('groucho_and_chica', 22),
+                altText: 'Groucho and Chica, sitting in separate boxes that are on top of each other'
+            },
+            {
+                src: getAssetUrl('groucho_and_chica', 23),
+                altText: 'Groucho and Chica, sitting inside a cabinet'
+            },
+            {
+                src: getAssetUrl('groucho_and_chica', 24),
+                altText: 'Groucho and Chica, laying down on a couch'
+            }
+        ]
     }
 };

--- a/src/input.css
+++ b/src/input.css
@@ -43,3 +43,50 @@
         opacity: 0.8;
     }
 }
+
+/* Photo carousel transitions */
+#photo-carousel[data-direction='next'] img {
+    animation: slideFromRight 0.3s ease-out forwards;
+}
+
+#photo-carousel[data-direction='prev'] img {
+    animation: slideFromLeft 0.3s ease-out forwards;
+}
+
+@keyframes slideFromRight {
+    0% {
+        opacity: 0;
+        transform: translateX(30px);
+    }
+    100% {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+
+@keyframes slideFromLeft {
+    0% {
+        opacity: 0;
+        transform: translateX(-30px);
+    }
+    100% {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+
+.animate-fade-out {
+    animation: fadeOut 2s ease-in-out forwards;
+}
+
+@keyframes fadeOut {
+    0% {
+        opacity: 1;
+    }
+    70% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0;
+    }
+}

--- a/src/types/cat.ts
+++ b/src/types/cat.ts
@@ -1,3 +1,5 @@
+import { Photo } from './photo.js';
+
 export interface Age {
     years: number;
     months: number;
@@ -6,10 +8,9 @@ export interface Age {
 export interface Cat {
     alias: string;
     displayName: string;
-    displayPronouns: string;
-    aboutItems: Array<string>;
+    displayPronouns?: string;
+    aboutItems?: Array<string>;
     navigationThumbnailImgSrc: string;
     navigationThumbnailImgAlt: string;
-    coverPhotoImgSrc: string;
-    coverPhotoImgAlt: string;
+    photos: Array<Photo>;
 }

--- a/src/types/photo.ts
+++ b/src/types/photo.ts
@@ -1,0 +1,4 @@
+export interface Photo {
+    src: string;
+    altText: string;
+}

--- a/views/main.html
+++ b/views/main.html
@@ -13,6 +13,7 @@
         <link href="/css/output.css" rel="stylesheet" />
         <link rel="icon" type="image/x-icon" href="/favicon.ico" />
         <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+        <script src="https://kit.fontawesome.com/08508bca30.js" crossorigin="anonymous"></script>
     </head>
     <body class="font-family-merriweather min-h-screen bg-gradient-to-br from-orange-50 via-white to-gray-100">
         <div class="container mx-auto px-4 py-8">


### PR DESCRIPTION
This pull request introduces a photo carousel feature for the cat "About" pages, allowing users to browse multiple photos of each cat with smooth transitions and improved accessibility. The implementation includes backend updates to serve photo data and frontend enhancements for interactive navigation and visual effects.

**Photo Carousel Feature**

* Added a new `renderPhotoCarousel` component to display multiple photos per cat, with navigation buttons, keyboard support, and accessibility improvements (`src/components/about.ts`, [src/components/about.tsR1-R144](diffhunk://#diff-d615a9c267b06fb8fb718a220ab67cdb4ecc02e16f137b087ce1e389785cebbcR1-R144)).
* Updated the `/about/:name` and `/about/:alias/photos/:index` routes to serve carousel data and handle photo navigation, including error handling for invalid aliases or indices (`routes/cats.ts`, [routes/cats.tsL113-R171](diffhunk://#diff-5f3f159fe8650c17e76afaf2909cf68fb3aabbba10e832dc509ddbc17dba28f9L113-R171)).

**Data Model and Structure Updates**

* Refactored the `Cat` type to use a new `Photo` type and replaced single cover photo fields with an array of photos for each cat (`src/types/cat.ts`, [[1]](diffhunk://#diff-c9e9f143fb6f449c83693b9b606ee2258fe6693d8ef9b955e48785a47e364ef6L9-R15); `src/types/photo.ts`, [[2]](diffhunk://#diff-5c07c0ed49319ccd3e15e56e60e0ac94f74551791a4b3b08aa0151cdf66bc6dbR1-R4).
* Expanded the `catsData` object to include detailed photo arrays for Groucho, Chica, and Groucho & Chica, and added a `VALID_ALIASES` constant for validation (`src/data/cats.ts`, [[1]](diffhunk://#diff-5d5bea80a644c6789aa02796c4502f523d3025f983614057edd67dad3672ed09L22-R111) [[2]](diffhunk://#diff-5d5bea80a644c6789aa02796c4502f523d3025f983614057edd67dad3672ed09L44-R329) [[3]](diffhunk://#diff-5d5bea80a644c6789aa02796c4502f523d3025f983614057edd67dad3672ed09R4-R5).

**Styling and Visual Enhancements**

* Added CSS transitions for photo carousel navigation (slide from left/right) and a fade-out animation for photo indicators (`src/input.css`, [src/input.cssR46-R92](diffhunk://#diff-979630d2b9075a9d57e3866b5028d27b19e721f2d5edab3dc04b57ddacb2490cR46-R92)).

These changes collectively provide a richer, more interactive experience for users exploring the cats' profiles, with robust backend support and polished frontend presentation.