### PR TITLE
add delay to showing the loading indicator for carousel

### DIFF
--- a/src/input.css
+++ b/src/input.css
@@ -75,6 +75,16 @@
     }
 }
 
+/* Delay loading indicator appearance */
+.htmx-indicator {
+    opacity: 0;
+    transition: opacity 0.2s ease-in 0.5s;
+}
+
+.htmx-request .htmx-indicator {
+    opacity: 1;
+}
+
 .animate-fade-out {
     animation: fadeOut 2s ease-in-out forwards;
 }


### PR DESCRIPTION
This pull request introduces a visual improvement to the loading indicator by delaying its appearance, resulting in a smoother user experience. The change uses CSS transitions to control the indicator's opacity and adds a delay before it becomes visible.

User experience enhancements:

* Added CSS rules to `.htmx-indicator` to delay its opacity transition, making the loading indicator appear only after 0.5 seconds of a request, reducing unnecessary flicker for fast responses. (`src/input.css`)