### PR TITLE
used more specific selectors for carousel css

### DIFF
--- a/src/input.css
+++ b/src/input.css
@@ -76,13 +76,20 @@
 }
 
 /* Delay loading indicator appearance */
-.htmx-indicator {
-    opacity: 0;
-    transition: opacity 0.2s ease-in 0.5s;
+#photo-carousel .htmx-indicator {
+    opacity: 0 !important;
+    visibility: hidden;
+    transition:
+        opacity 0.2s ease-in 0.5s,
+        visibility 0s linear 0.5s;
 }
 
-.htmx-request .htmx-indicator {
-    opacity: 1;
+#photo-carousel.htmx-request .htmx-indicator {
+    opacity: 1 !important;
+    visibility: visible;
+    transition:
+        opacity 0.2s ease-in 0.5s,
+        visibility 0s linear 0s;
 }
 
 .animate-fade-out {


### PR DESCRIPTION
This pull request updates the loading indicator styling for the photo carousel component to improve its appearance and behavior. The most important changes are:

Photo carousel loading indicator improvements:
* Scoped the `.htmx-indicator` styles to `#photo-carousel` to ensure the loading indicator only affects the photo carousel and not other components.
* Added `!important` to `opacity` and set `visibility` to hidden/visible to better control the indicator's display state during requests.
* Enhanced transitions for both `opacity` and `visibility` to create a smoother loading indicator animation.