### PR TITLE
adjusted css for carousel for subtle issues in prod

### DIFF
--- a/src/input.css
+++ b/src/input.css
@@ -45,6 +45,11 @@
 }
 
 /* Photo carousel transitions */
+#photo-carousel img {
+    opacity: 1;
+    transform: translateX(0);
+}
+
 #photo-carousel[data-direction='next'] img {
     animation: slideFromRight 0.3s ease-out forwards;
 }
@@ -54,24 +59,16 @@
 }
 
 @keyframes slideFromRight {
-    0% {
+    from {
         opacity: 0;
         transform: translateX(30px);
-    }
-    100% {
-        opacity: 1;
-        transform: translateX(0);
     }
 }
 
 @keyframes slideFromLeft {
-    0% {
+    from {
         opacity: 0;
         transform: translateX(-30px);
-    }
-    100% {
-        opacity: 1;
-        transform: translateX(0);
     }
 }
 


### PR DESCRIPTION
This pull request improves the photo carousel transitions in the `src/input.css` file by refining animation keyframes and ensuring consistent initial styles for carousel images.

Photo carousel transition improvements:

* Set a default style for images in the `#photo-carousel` to ensure they start fully visible and in place, which helps prevent unwanted visual artifacts when animations run.
* Updated the `slideFromRight` and `slideFromLeft` keyframes to use the `from` keyword instead of `0%`, and removed the explicit `100%` definitions. This makes the keyframes more concise and easier to maintain.