### PR TITLE
fix carousel height to 448px and fix hx-swap from innerHTML to outerHTML

### DIFF
--- a/src/components/about.ts
+++ b/src/components/about.ts
@@ -40,7 +40,7 @@ export function renderPhotoCarousel({
     return /* html */ `
         <div
             id="photo-carousel"
-            class="relative bg-stone-900"
+            class="relative bg-stone-900 h-[448px]"
             tabindex="0"
             ${transitionDirection ? `data-direction="${transitionDirection}"` : ''}
             role="region"
@@ -65,11 +65,13 @@ export function renderPhotoCarousel({
         >
             ${nextImageSrc ? `<link rel="prefetch" href="${nextImageSrc}" as="image">` : ''}
             ${prevImageSrc ? `<link rel="prefetch" href="${prevImageSrc}" as="image">` : ''}
-            <img
-                alt="${imageAlt}"
-                src="${imageSrc}"
-                class="max-h-[480px] min-h-[360px] w-full object-contain carousel-image"
-            />
+            <div class="absolute inset-0 flex items-center justify-center">
+                <img
+                    alt="${imageAlt}"
+                    src="${imageSrc}"
+                    class="object-contain max-h-full max-w-full"
+                />
+            </div>
             <span class="sr-only" aria-live="polite">Photo ${currentIndex + 1} of ${numPhotos}: ${imageAlt}</span>
             ${
                 showNavigation
@@ -85,7 +87,7 @@ export function renderPhotoCarousel({
                 <button
                     class="absolute top-1/2 -translate-y-1/2 left-2 bg-white/50 hover:bg-white/90 rounded-full w-8 h-8 flex items-center justify-center shadow-md hover:shadow-lg cursor-pointer transition-all disabled:opacity-50"
                     hx-get="/api/cats/about/${alias}/photos/${prevIndex.toString()}?direction=prev"
-                    hx-swap="innerHTML swap:0.3s"
+                    hx-swap="outerHTML swap:0.3s"
                     hx-target="#photo-carousel"
                     hx-indicator="#photo-carousel"
                     aria-label="Previous photo"
@@ -95,7 +97,7 @@ export function renderPhotoCarousel({
                 <button
                     class="absolute top-1/2 -translate-y-1/2 right-2 bg-white/50 hover:bg-white/90 rounded-full w-8 h-8 flex items-center justify-center shadow-md hover:shadow-lg cursor-pointer transition-all disabled:opacity-50"
                     hx-get="/api/cats/about/${alias}/photos/${nextIndex.toString()}?direction=next"
-                    hx-swap="innerHTML swap:0.3s"
+                    hx-swap="outerHTML swap:0.3s"
                     hx-target="#photo-carousel"
                     hx-indicator="#photo-carousel"
                     aria-label="Next photo"

--- a/views/main.html
+++ b/views/main.html
@@ -29,11 +29,6 @@
                         hx-trigger="load"
                         hx-swap="innerHTML"
                     >
-                        <img
-                            alt="Groucho and Chica laying down together"
-                            src="/img/about_grouchi_1.jpg"
-                            class="max-h-[480px] w-full object-cover"
-                        />
                         <div class="p-8">
                             <h2 class="mb-4 text-2xl font-bold text-gray-800">Loading...</h2>
                         </div>


### PR DESCRIPTION
This pull request updates the photo carousel in the `about` section to improve layout consistency and navigation behavior. The main changes include enforcing a fixed height for the carousel, updating image centering and scaling, changing navigation button swapping behavior, and removing a redundant static image from the main view.

**Photo carousel layout and behavior improvements:**

* Set a fixed height (`h-[448px]`) for the carousel container to ensure consistent sizing across images.
* Center the image vertically and horizontally using a flex container, and update the image's classes to scale within the container using `max-h-full max-w-full object-contain`.
* Changed navigation buttons to use `hx-swap="outerHTML"` instead of `innerHTML` for smoother transitions and to ensure the carousel container is fully replaced on navigation. [[1]](diffhunk://#diff-d615a9c267b06fb8fb718a220ab67cdb4ecc02e16f137b087ce1e389785cebbcL88-R90) [[2]](diffhunk://#diff-d615a9c267b06fb8fb718a220ab67cdb4ecc02e16f137b087ce1e389785cebbcL98-R100)

**Main view cleanup:**

* Removed a static image from `views/main.html` that was previously displayed before the carousel loads, leaving only the loading indicator.