### PR TITLE
Separate cards for each cat and implement card swapping

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -35,7 +35,6 @@ export default [
             }
         },
         rules: {
-            ...prettierConfig.rules,
             '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
             'no-unused-vars': 'off',
             'no-console': 'off',
@@ -59,11 +58,29 @@ export default [
             }
         },
         rules: {
-            ...prettierConfig.rules,
             'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
             'no-console': 'off'
         }
     },
+    {
+        files: ['public/js/**/*.js'],
+        languageOptions: {
+            ecmaVersion: 'latest',
+            sourceType: 'script',
+            globals: {
+                console: 'readonly',
+                window: 'readonly',
+                document: 'readonly',
+                setTimeout: 'readonly',
+                htmx: 'readonly'
+            }
+        },
+        rules: {
+            'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+            'no-console': 'off'
+        }
+    },
+    prettierConfig,
     {
         ignores: ['node_modules/', 'public/css/', '*.min.js', 'dist/']
     }

--- a/public/js/cardSwap.js
+++ b/public/js/cardSwap.js
@@ -1,0 +1,118 @@
+// Card swap functionality for the stacked cards UI
+
+// Define position styles as constants
+const POSITIONS = {
+    center: 'relative z-10 transition-all duration-500',
+    left: 'absolute left-0 right-0 top-0 -rotate-2 -translate-x-96 translate-y-4 transform transition-all duration-500 hover:-translate-x-[28rem] hover:-rotate-3 hover:translate-y-2 cursor-pointer',
+    right: 'absolute left-0 right-0 top-0 translate-x-96 translate-y-4 rotate-2 transform transition-all duration-500 hover:translate-x-[28rem] hover:rotate-3 hover:translate-y-2 cursor-pointer'
+};
+
+let isSwapping = false;
+
+function normalizeCardName(name) {
+    return name === 'both' ? 'groucho_and_chica' : name;
+}
+
+function getCardsByPosition() {
+    const cards = {
+        groucho: document.getElementById('card-groucho'),
+        chica: document.getElementById('card-chica'),
+        both: document.getElementById('card-both')
+    };
+
+    const positions = { center: null, left: null, right: null };
+
+    for (const [cat, card] of Object.entries(cards)) {
+        if (!card) continue;
+
+        const pos = card.dataset.position;
+        if (pos) {
+            positions[pos] = {
+                element: card,
+                cat: normalizeCardName(cat)
+            };
+        }
+    }
+
+    return positions;
+}
+
+function updateCardPosition(card, newPosition, clickHandler) {
+    card.element.className = POSITIONS[newPosition];
+    card.element.dataset.position = newPosition;
+    card.element.onclick = clickHandler;
+}
+
+function updateCardContent(card, showCarousel) {
+    const aboutSection = card.element.querySelector('[id^="about"]');
+    if (!aboutSection) return;
+
+    const endpoint = `/api/cats/about/${card.cat}?show_carousel=${showCarousel}`;
+
+    htmx.ajax('GET', endpoint, {
+        target: aboutSection,
+        swap: 'innerHTML'
+    });
+}
+
+function swapBackgroundColors(cards) {
+    const innerDivs = cards.map((card) => card.element.querySelector('div > div'));
+
+    const colors = innerDivs.map((div) => div?.className || '');
+
+    // Rotate colors: 0 -> 1, 1 -> 2, 2 -> 0
+    innerDivs.forEach((div, i) => {
+        if (div) {
+            div.className = colors[(i + 1) % colors.length];
+        }
+    });
+}
+
+function swapCards(clickedCat) {
+    if (isSwapping) return;
+    isSwapping = true;
+
+    const positions = getCardsByPosition();
+
+    // Validate clicked card
+    if (
+        !positions.left ||
+        !positions.right ||
+        !positions.center ||
+        positions.center.cat === clickedCat ||
+        (positions.left.cat !== clickedCat && positions.right.cat !== clickedCat)
+    ) {
+        isSwapping = false;
+        return;
+    }
+
+    const isLeftClicked = positions.left.cat === clickedCat;
+    const clicked = isLeftClicked ? positions.left : positions.right;
+    const other = isLeftClicked ? positions.right : positions.left;
+    const center = positions.center;
+
+    // Three-way rotation
+    // Clicked -> Center
+    updateCardPosition(clicked, 'center', null);
+
+    // Center -> Opposite of clicked
+    updateCardPosition(center, isLeftClicked ? 'right' : 'left', () => swapCards(center.cat));
+
+    // Other -> Clicked position
+    updateCardPosition(other, isLeftClicked ? 'left' : 'right', () => swapCards(other.cat));
+
+    // Update carousel states
+    updateCardContent(clicked, true); // New center gets carousel
+    updateCardContent(center, false); // Old center loses carousel
+
+    // Rotate background colors
+    swapBackgroundColors([clicked, center, other]);
+
+    // Re-enable swapping after animation
+    setTimeout(() => {
+        isSwapping = false;
+    }, 500);
+}
+
+// Make swapCards available globally for onclick handlers
+window.swapCards = swapCards;

--- a/routes/cats.ts
+++ b/routes/cats.ts
@@ -63,7 +63,7 @@ router.get('/about_navigation/:view', (req: Request, res: Response): void => {
     res.send(html);
 });
 
-router.get('/about/groucho_and_chica', (_req: Request, res: Response): void => {
+router.get('/about/groucho_and_chica', (req: Request, res: Response): void => {
     const birthDate = new Date('2021-07-02');
     const { years, months } = calculateAge(birthDate);
 
@@ -96,7 +96,8 @@ router.get('/about/groucho_and_chica', (_req: Request, res: Response): void => {
         aboutItems,
         initialPhoto: photos[0],
         photos,
-        numPhotos: photos.length
+        numPhotos: photos.length,
+        shouldRenderCarousel: req.query.show_carousel === 'true'
     });
 
     res.send(html);
@@ -123,7 +124,8 @@ router.get('/about/:name', (req: Request, res: Response): void => {
         aboutItems: aboutItems,
         initialPhoto: photos[0],
         photos,
-        numPhotos: photos.length
+        numPhotos: photos.length,
+        shouldRenderCarousel: req.query.show_carousel === 'true'
     });
 
     res.send(html);

--- a/src/components/about.ts
+++ b/src/components/about.ts
@@ -8,6 +8,7 @@ export type AboutSectionProps = {
     initialPhoto: Photo;
     photos: Photo[];
     numPhotos: number;
+    shouldRenderCarousel?: boolean;
 };
 
 export type PhotoCarouselProps = {
@@ -121,7 +122,8 @@ export function renderAboutSection({
     aboutItems = [],
     initialPhoto,
     photos,
-    numPhotos
+    numPhotos,
+    shouldRenderCarousel = false
 }: AboutSectionProps): string {
     const listHtml = aboutItems.map((item) => `<li>${item}</li>`).join('');
 
@@ -133,17 +135,31 @@ export function renderAboutSection({
     const prevImageSrc = photos[prevPhotoIndex]?.src;
 
     return /* html */ `
-        ${renderPhotoCarousel({
-            alias,
-            imageSrc: src,
-            imageAlt: altText,
-            nextIndex: nextPhotoIndex,
-            prevIndex: prevPhotoIndex,
-            nextImageSrc,
-            prevImageSrc,
-            currentIndex: 0,
-            numPhotos
-        })}
+        ${
+            shouldRenderCarousel
+                ? renderPhotoCarousel({
+                      alias,
+                      imageSrc: src,
+                      imageAlt: altText,
+                      nextIndex: nextPhotoIndex,
+                      prevIndex: prevPhotoIndex,
+                      nextImageSrc,
+                      prevImageSrc,
+                      currentIndex: 0,
+                      numPhotos
+                  })
+                : /* html */ `
+            <div class="relative bg-stone-900 h-[448px]">
+                <div class="absolute inset-0 flex items-center justify-center">
+                    <img
+                        alt="${altText}"
+                        src="${src}"
+                        class="object-contain max-h-full max-w-full"
+                    />
+                </div>
+            </div>
+        `
+        }
         <div class="p-8">
             <h2 class="${subtitle ? 'mb-2' : 'mb-4'} text-2xl font-bold text-gray-800">${title}</h2>
             ${subtitle ? /* html */ `<p class="mb-4 text-gray-500 italic">${subtitle}</p>` : ''}

--- a/views/main.html
+++ b/views/main.html
@@ -22,32 +22,186 @@
             </header>
 
             <main>
-                <div class="mx-auto mt-12 max-w-2xl overflow-hidden rounded-lg bg-orange-50 shadow-lg">
+                <!-- Stacked cards container -->
+                <div id="cards-container" class="relative mx-auto mt-12 max-w-2xl">
+                    <!-- Groucho card (back left) -->
                     <div
-                        id="about-section"
-                        hx-get="/api/cats/about/groucho_and_chica"
-                        hx-trigger="load"
-                        hx-swap="innerHTML"
+                        id="card-groucho"
+                        class="absolute top-0 right-0 left-0 -translate-x-96 translate-y-4 -rotate-2 transform cursor-pointer transition-all duration-500 hover:-translate-x-[28rem] hover:translate-y-2 hover:-rotate-3"
+                        data-position="left"
+                        data-cat="groucho"
+                        onclick="swapCards('groucho')"
                     >
-                        <div class="p-8">
-                            <h2 class="mb-4 text-2xl font-bold text-gray-800">Loading...</h2>
+                        <div
+                            class="overflow-hidden rounded-lg bg-blue-50 opacity-60 shadow-lg transition-all duration-300 hover:opacity-90 hover:shadow-xl"
+                        >
+                            <div
+                                id="about-groucho"
+                                hx-get="/api/cats/about/groucho?show_carousel=false"
+                                hx-trigger="load"
+                                hx-swap="innerHTML"
+                            >
+                                <div class="p-8">
+                                    <h2 class="mb-4 text-2xl font-bold text-gray-800">Loading...</h2>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Chica card (back right) -->
+                    <div
+                        id="card-chica"
+                        class="absolute top-0 right-0 left-0 translate-x-96 translate-y-4 rotate-2 transform cursor-pointer transition-all duration-500 hover:translate-x-[28rem] hover:translate-y-2 hover:rotate-3"
+                        data-position="right"
+                        data-cat="chica"
+                        onclick="swapCards('chica')"
+                    >
+                        <div
+                            class="overflow-hidden rounded-lg bg-pink-50 opacity-60 shadow-lg transition-all duration-300 hover:opacity-90 hover:shadow-xl"
+                        >
+                            <div
+                                id="about-chica"
+                                hx-get="/api/cats/about/chica?show_carousel=false"
+                                hx-trigger="load"
+                                hx-swap="innerHTML"
+                            >
+                                <div class="p-8">
+                                    <h2 class="mb-4 text-2xl font-bold text-gray-800">Loading...</h2>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Main card (Groucho & Chica) -->
+                    <div
+                        id="card-both"
+                        class="relative z-10 transition-all duration-500"
+                        data-position="center"
+                        data-cat="groucho_and_chica"
+                    >
+                        <div class="overflow-hidden rounded-lg bg-orange-50 shadow-2xl/35">
+                            <div
+                                id="about-both"
+                                hx-get="/api/cats/about/groucho_and_chica?show_carousel=true"
+                                hx-trigger="load"
+                                hx-swap="innerHTML"
+                            >
+                                <div class="p-8">
+                                    <h2 class="mb-4 text-2xl font-bold text-gray-800">Loading...</h2>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>
 
-                <div class="mx-auto mt-12 max-w-2xl rounded-lg border-2 border-gray-900 bg-white p-8 shadow-lg">
-                    <h2 class="mb-4 text-2xl font-bold text-gray-800">Learn More</h2>
+                <script>
+                    let isSwapping = false;
 
-                    <div
-                        id="about-navigation-section"
-                        class="flex flex-row gap-4"
-                        hx-get="/api/cats/about_navigation/groucho_and_chica"
-                        hx-trigger="load"
-                        hx-swap="innerHTML"
-                    >
-                        <div class="flex-1 text-center">Loading navigation...</div>
-                    </div>
-                </div>
+                    function swapCards(clickedCat) {
+                        if (isSwapping) return;
+                        isSwapping = true;
+
+                        const cards = {
+                            groucho: document.getElementById('card-groucho'),
+                            chica: document.getElementById('card-chica'),
+                            both: document.getElementById('card-both')
+                        };
+
+                        // Find all card positions
+                        let centerCard = null;
+                        let leftCard = null;
+                        let rightCard = null;
+
+                        for (const [cat, card] of Object.entries(cards)) {
+                            if (card.dataset.position === 'center') {
+                                centerCard = { element: card, cat: cat === 'both' ? 'groucho_and_chica' : cat };
+                            } else if (card.dataset.position === 'left') {
+                                leftCard = { element: card, cat: cat === 'both' ? 'groucho_and_chica' : cat };
+                            } else if (card.dataset.position === 'right') {
+                                rightCard = { element: card, cat: cat === 'both' ? 'groucho_and_chica' : cat };
+                            }
+                        }
+
+                        // Don't swap if clicking the center card
+                        if (centerCard.cat === clickedCat) {
+                            isSwapping = false;
+                            return;
+                        }
+
+                        // Determine which card was clicked
+                        const clickedCard = leftCard.cat === clickedCat ? leftCard : rightCard;
+                        const otherBackCard = leftCard.cat === clickedCat ? rightCard : leftCard;
+
+                        // Three-way rotation: clicked -> center, center -> other back, other back -> clicked position
+
+                        // 1. Move clicked card to center
+                        clickedCard.element.className = 'relative z-10 transition-all duration-500';
+                        clickedCard.element.dataset.position = 'center';
+                        clickedCard.element.onclick = null;
+
+                        // 2. Move center card to the other back position (opposite of clicked)
+                        if (clickedCard === leftCard) {
+                            // Center goes to right
+                            centerCard.element.className =
+                                'absolute left-0 right-0 top-0 translate-x-96 translate-y-4 rotate-2 transform transition-all duration-500 hover:translate-x-[28rem] hover:rotate-3 hover:translate-y-2 cursor-pointer';
+                            centerCard.element.dataset.position = 'right';
+                        } else {
+                            // Center goes to left
+                            centerCard.element.className =
+                                'absolute left-0 right-0 top-0 -rotate-2 -translate-x-96 translate-y-4 transform transition-all duration-500 hover:-translate-x-[28rem] hover:-rotate-3 hover:translate-y-2 cursor-pointer';
+                            centerCard.element.dataset.position = 'left';
+                        }
+                        centerCard.element.onclick = () => swapCards(centerCard.cat);
+
+                        // 3. Move other back card to clicked position
+                        if (clickedCard === leftCard) {
+                            // Right card goes to left
+                            otherBackCard.element.className =
+                                'absolute left-0 right-0 top-0 -rotate-2 -translate-x-96 translate-y-4 transform transition-all duration-500 hover:-translate-x-[28rem] hover:-rotate-3 hover:translate-y-2 cursor-pointer';
+                            otherBackCard.element.dataset.position = 'left';
+                        } else {
+                            // Left card goes to right
+                            otherBackCard.element.className =
+                                'absolute left-0 right-0 top-0 translate-x-96 translate-y-4 rotate-2 transform transition-all duration-500 hover:translate-x-[28rem] hover:rotate-3 hover:translate-y-2 cursor-pointer';
+                            otherBackCard.element.dataset.position = 'right';
+                        }
+                        otherBackCard.element.onclick = () => swapCards(otherBackCard.cat);
+
+                        // Update carousel settings
+                        const clickedAbout = clickedCard.element.querySelector('[id^="about"]');
+                        const centerAbout = centerCard.element.querySelector('[id^="about"]');
+
+                        // Enable carousel for new center
+                        const clickedEndpoint = '/api/cats/about/' + clickedCard.cat;
+                        htmx.ajax('GET', clickedEndpoint + '?show_carousel=true', {
+                            target: clickedAbout,
+                            swap: 'innerHTML'
+                        });
+
+                        // Disable carousel for old center
+                        const centerEndpoint = '/api/cats/about/' + centerCard.cat;
+                        htmx.ajax('GET', centerEndpoint + '?show_carousel=false', {
+                            target: centerAbout,
+                            swap: 'innerHTML'
+                        });
+
+                        // Update background colors
+                        const clickedInner = clickedCard.element.querySelector('div > div');
+                        const centerInner = centerCard.element.querySelector('div > div');
+                        const otherInner = otherBackCard.element.querySelector('div > div');
+
+                        // Three-way color swap
+                        const tempClasses = clickedInner.className;
+                        clickedInner.className = centerInner.className;
+                        centerInner.className = otherInner.className;
+                        otherInner.className = tempClasses;
+
+                        // Re-enable swapping after animation completes
+                        setTimeout(() => {
+                            isSwapping = false;
+                        }, 500);
+                    }
+                </script>
             </main>
 
             <footer class="mt-12 text-center text-gray-600">

--- a/views/main.html
+++ b/views/main.html
@@ -93,120 +93,13 @@
                         </div>
                     </div>
                 </div>
-
-                <script>
-                    let isSwapping = false;
-
-                    function swapCards(clickedCat) {
-                        if (isSwapping) return;
-                        isSwapping = true;
-
-                        const cards = {
-                            groucho: document.getElementById('card-groucho'),
-                            chica: document.getElementById('card-chica'),
-                            both: document.getElementById('card-both')
-                        };
-
-                        // Find all card positions
-                        let centerCard = null;
-                        let leftCard = null;
-                        let rightCard = null;
-
-                        for (const [cat, card] of Object.entries(cards)) {
-                            if (card.dataset.position === 'center') {
-                                centerCard = { element: card, cat: cat === 'both' ? 'groucho_and_chica' : cat };
-                            } else if (card.dataset.position === 'left') {
-                                leftCard = { element: card, cat: cat === 'both' ? 'groucho_and_chica' : cat };
-                            } else if (card.dataset.position === 'right') {
-                                rightCard = { element: card, cat: cat === 'both' ? 'groucho_and_chica' : cat };
-                            }
-                        }
-
-                        // Don't swap if clicking the center card
-                        if (centerCard.cat === clickedCat) {
-                            isSwapping = false;
-                            return;
-                        }
-
-                        // Determine which card was clicked
-                        const clickedCard = leftCard.cat === clickedCat ? leftCard : rightCard;
-                        const otherBackCard = leftCard.cat === clickedCat ? rightCard : leftCard;
-
-                        // Three-way rotation: clicked -> center, center -> other back, other back -> clicked position
-
-                        // 1. Move clicked card to center
-                        clickedCard.element.className = 'relative z-10 transition-all duration-500';
-                        clickedCard.element.dataset.position = 'center';
-                        clickedCard.element.onclick = null;
-
-                        // 2. Move center card to the other back position (opposite of clicked)
-                        if (clickedCard === leftCard) {
-                            // Center goes to right
-                            centerCard.element.className =
-                                'absolute left-0 right-0 top-0 translate-x-96 translate-y-4 rotate-2 transform transition-all duration-500 hover:translate-x-[28rem] hover:rotate-3 hover:translate-y-2 cursor-pointer';
-                            centerCard.element.dataset.position = 'right';
-                        } else {
-                            // Center goes to left
-                            centerCard.element.className =
-                                'absolute left-0 right-0 top-0 -rotate-2 -translate-x-96 translate-y-4 transform transition-all duration-500 hover:-translate-x-[28rem] hover:-rotate-3 hover:translate-y-2 cursor-pointer';
-                            centerCard.element.dataset.position = 'left';
-                        }
-                        centerCard.element.onclick = () => swapCards(centerCard.cat);
-
-                        // 3. Move other back card to clicked position
-                        if (clickedCard === leftCard) {
-                            // Right card goes to left
-                            otherBackCard.element.className =
-                                'absolute left-0 right-0 top-0 -rotate-2 -translate-x-96 translate-y-4 transform transition-all duration-500 hover:-translate-x-[28rem] hover:-rotate-3 hover:translate-y-2 cursor-pointer';
-                            otherBackCard.element.dataset.position = 'left';
-                        } else {
-                            // Left card goes to right
-                            otherBackCard.element.className =
-                                'absolute left-0 right-0 top-0 translate-x-96 translate-y-4 rotate-2 transform transition-all duration-500 hover:translate-x-[28rem] hover:rotate-3 hover:translate-y-2 cursor-pointer';
-                            otherBackCard.element.dataset.position = 'right';
-                        }
-                        otherBackCard.element.onclick = () => swapCards(otherBackCard.cat);
-
-                        // Update carousel settings
-                        const clickedAbout = clickedCard.element.querySelector('[id^="about"]');
-                        const centerAbout = centerCard.element.querySelector('[id^="about"]');
-
-                        // Enable carousel for new center
-                        const clickedEndpoint = '/api/cats/about/' + clickedCard.cat;
-                        htmx.ajax('GET', clickedEndpoint + '?show_carousel=true', {
-                            target: clickedAbout,
-                            swap: 'innerHTML'
-                        });
-
-                        // Disable carousel for old center
-                        const centerEndpoint = '/api/cats/about/' + centerCard.cat;
-                        htmx.ajax('GET', centerEndpoint + '?show_carousel=false', {
-                            target: centerAbout,
-                            swap: 'innerHTML'
-                        });
-
-                        // Update background colors
-                        const clickedInner = clickedCard.element.querySelector('div > div');
-                        const centerInner = centerCard.element.querySelector('div > div');
-                        const otherInner = otherBackCard.element.querySelector('div > div');
-
-                        // Three-way color swap
-                        const tempClasses = clickedInner.className;
-                        clickedInner.className = centerInner.className;
-                        centerInner.className = otherInner.className;
-                        otherInner.className = tempClasses;
-
-                        // Re-enable swapping after animation completes
-                        setTimeout(() => {
-                            isSwapping = false;
-                        }, 500);
-                    }
-                </script>
             </main>
 
             <footer class="mt-12 text-center text-gray-600">
                 <p class="mt-2 text-sm">Built with HTMX, Tailwind CSS, and Express.js</p>
             </footer>
         </div>
+
+        <script src="/js/cardSwap.js"></script>
     </body>
 </html>

--- a/views/main.html
+++ b/views/main.html
@@ -30,7 +30,6 @@
                         class="absolute top-0 right-0 left-0 -translate-x-96 translate-y-4 -rotate-2 transform cursor-pointer transition-all duration-500 hover:-translate-x-[28rem] hover:translate-y-2 hover:-rotate-3"
                         data-position="left"
                         data-cat="groucho"
-                        onclick="swapCards('groucho')"
                     >
                         <div
                             class="overflow-hidden rounded-lg bg-blue-50 opacity-60 shadow-lg transition-all duration-300 hover:opacity-90 hover:shadow-xl"
@@ -54,7 +53,6 @@
                         class="absolute top-0 right-0 left-0 translate-x-96 translate-y-4 rotate-2 transform cursor-pointer transition-all duration-500 hover:translate-x-[28rem] hover:translate-y-2 hover:rotate-3"
                         data-position="right"
                         data-cat="chica"
-                        onclick="swapCards('chica')"
                     >
                         <div
                             class="overflow-hidden rounded-lg bg-pink-50 opacity-60 shadow-lg transition-all duration-300 hover:opacity-90 hover:shadow-xl"


### PR DESCRIPTION
This pull request introduces a new interactive stacked card UI to the main page, allowing users to swap between Groucho, Chica, and Groucho & Chica cards with smooth animations. The implementation includes a new client-side script for card swapping, updates to the backend to support dynamic carousel rendering, and corresponding changes to the frontend and component logic.

**UI/UX Enhancements:**

* Added a stacked card layout to `views/main.html` for Groucho, Chica, and Groucho & Chica, each with distinct positioning, styling, and HTMX endpoints for dynamic content loading. [[1]](diffhunk://#diff-6d82229c7876407e533f5fbed029666672b12da702c82c4c2d0db489a63045c9L25-R39) [[2]](diffhunk://#diff-6d82229c7876407e533f5fbed029666672b12da702c82c4c2d0db489a63045c9R48-R91)
* Integrated the new `public/js/cardSwap.js` script to handle card swapping, position transitions, carousel toggling, and background color rotation. [[1]](diffhunk://#diff-89f14219ab992f27f507bae797354136e5a9825f600838c15a8b29f9e04fb1f1R1-R138) [[2]](diffhunk://#diff-6d82229c7876407e533f5fbed029666672b12da702c82c4c2d0db489a63045c9R100-R101)

**Backend/API Updates:**

* Updated `/api/cats/about/:name` and `/api/cats/about/groucho_and_chica` endpoints in `routes/cats.ts` to accept a `show_carousel` query parameter, allowing conditional rendering of the photo carousel. [[1]](diffhunk://#diff-5f3f159fe8650c17e76afaf2909cf68fb3aabbba10e832dc509ddbc17dba28f9L66-R66) [[2]](diffhunk://#diff-5f3f159fe8650c17e76afaf2909cf68fb3aabbba10e832dc509ddbc17dba28f9L99-R100) [[3]](diffhunk://#diff-5f3f159fe8650c17e76afaf2909cf68fb3aabbba10e832dc509ddbc17dba28f9L126-R128)

**Component Logic Changes:**

* Modified `AboutSectionProps` and `renderAboutSection` in `src/components/about.ts` to support an optional `shouldRenderCarousel` prop, and conditionally render either the carousel or a static image based on its value. [[1]](diffhunk://#diff-d615a9c267b06fb8fb718a220ab67cdb4ecc02e16f137b087ce1e389785cebbcR11) [[2]](diffhunk://#diff-d615a9c267b06fb8fb718a220ab67cdb4ecc02e16f137b087ce1e389785cebbcL124-R126) [[3]](diffhunk://#diff-d615a9c267b06fb8fb718a220ab67cdb4ecc02e16f137b087ce1e389785cebbcL136-R140) [[4]](diffhunk://#diff-d615a9c267b06fb8fb718a220ab67cdb4ecc02e16f137b087ce1e389785cebbcL146-R162)

**Linting/Config Updates:**

* Updated `eslint.config.js` to add a separate config for scripts in `public/js/`, ensuring proper linting for browser globals and script files. [[1]](diffhunk://#diff-a32a0887ed9d1d707bbb3b845b7df7fd40e673c47e7b60a3ebd896b68d3b8839L38) [[2]](diffhunk://#diff-a32a0887ed9d1d707bbb3b845b7df7fd40e673c47e7b60a3ebd896b68d3b8839L62-R83)

<img width="1808" height="1244" alt="image" src="https://github.com/user-attachments/assets/96407616-bf96-4522-ae29-09c126f2296d" />
